### PR TITLE
Change TCON to TPE1 on artist check for MP3 files

### DIFF
--- a/track_preparation/initiateTrack/initiateMP3.py
+++ b/track_preparation/initiateTrack/initiateMP3.py
@@ -15,7 +15,7 @@ from track_preparation.initiateTrack.commonInitiationOperations import saveThumb
 def initiateMP3(filename, directory, thumbnails, options):
     audio = MP3(str(directory) + "/" + str(filename))
     # verify artist information is present before preceeding
-    if ' - ' not in filename and str(audio['TCON']) == '':
+    if ' - ' not in filename and str(audio['TPE1']) == '':
         messagebox.showinfo("No artist information found, aborting procedure")
         return False, False, False
 


### PR DESCRIPTION
I was trying to get some MP3 files tagged but it kept throwing an error.
Looked into the source code and saw that when performing the check for the artists the code was using the `TCON` tag instead of `TPE1`. Changed it to the right one and it works.